### PR TITLE
#0330 네트워크 보간 (클라이언트 예측 보간 완성)

### DIFF
--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -97,6 +97,7 @@ ManualIPAddress=
 
 
 [CoreRedirects]
++ClassRedirects=(OldName="/Script/ProjectR.UNetworkInterpolationStrategy",NewName="/Script/ProjectR.NetworkInterpolationStrategy")
 
 [/Script/Engine.GameEngine]
 +NetDriverDefinitions=(DefName="GameNetDriver",DriverClassName="OnlineSubsystemSteam.SteamNetDriver",DriverClassNameFallback="OnlineSubsystemUtils.IpNetDriver")

--- a/Config/DefaultEngine.ini
+++ b/Config/DefaultEngine.ini
@@ -98,6 +98,7 @@ ManualIPAddress=
 
 [CoreRedirects]
 +ClassRedirects=(OldName="/Script/ProjectR.UNetworkInterpolationStrategy",NewName="/Script/ProjectR.NetworkInterpolationStrategy")
++ClassRedirects=(OldName="/Script/ProjectR.NetworkTimeComponent",NewName="/Script/ProjectR.NetworkClockComponent")
 
 [/Script/Engine.GameEngine]
 +NetDriverDefinitions=(DefName="GameNetDriver",DriverClassName="OnlineSubsystemSteam.SteamNetDriver",DriverClassNameFallback="OnlineSubsystemUtils.IpNetDriver")

--- a/Source/ProjectR/KartGame/Games/Component/NetworkClockComponent.cpp
+++ b/Source/ProjectR/KartGame/Games/Component/NetworkClockComponent.cpp
@@ -1,0 +1,75 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "NetworkClockComponent.h"
+
+#include "FastLogger.h"
+#include "KartGame/Games/Modes/Race/RaceGameState.h"
+
+
+// Sets default values for this component's properties
+UNetworkClockComponent::UNetworkClockComponent()
+{
+	// Set this component to be initialized when the game starts, and to be ticked every frame.  You can turn these features
+	// off to improve performance if you don't need them.
+	PrimaryComponentTick.bCanEverTick = true;
+	SetIsReplicatedByDefault(true);
+	// ...
+}
+
+
+// Called when the game starts
+void UNetworkClockComponent::BeginPlay()
+{
+	Super::BeginPlay();
+
+	// ...
+	
+}
+
+
+// Called every frame
+void UNetworkClockComponent::TickComponent(float DeltaTime, ELevelTick TickType,
+                                          FActorComponentTickFunction* ThisTickFunction)
+{
+	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+	// 매틱마다 클라이언트가 직접 시간을 업데이트 한다.
+	// 서버에서 시간을 한번 동기화 처리 된 이후 직접 계산을 함.
+	// 서버에서 동기화 될 때 네트워크 지연을 고려하여 세팅해주기 때문에 이후에 클라이언트에서
+	// 해당 시간을 계속해서 업데이트 해주면 완전히 일치한 시간을 가질 수 있다.
+	ServerTime += DeltaTime;
+}
+
+void UNetworkClockComponent::RequestServerTime(APlayerController* Requester)
+{
+	if (Requester->GetLocalRole() < ROLE_Authority)
+	{
+		// 클라이언트가 서버에게 시간을 요청한다.
+		ServerRPC_RequestServerTime(Requester, GetWorld()->GetTimeSeconds());
+	}
+}
+
+void UNetworkClockComponent::ServerRPC_RequestServerTime_Implementation(APlayerController* Requester, float RequestTime)
+{
+	float InServerTime = GetWorld()->GetGameState()->GetServerWorldTimeSeconds();
+
+	FFastLogger::LogConsole(TEXT("Player %s Requested Server Time: %f"), *Requester->GetName(), ServerTime);
+	
+	ClientRPC_ReceiveServerTime(InServerTime, RequestTime);
+}
+
+void UNetworkClockComponent::ClientRPC_ReceiveServerTime_Implementation(float InServerTime, float RequestTime)
+{
+	// 서버로부터 받은 시간과 클라이언트가 요청한 시간을 비교하여 네트워크 지연을 계산한다.
+
+	// 현재 시간과 요청했던 시간의 차이를 계산한다.
+	// 이것이 네트워크 왕복 시간이 됨.
+	float RoundTrip = GetWorld()->GetTimeSeconds() - RequestTime;
+	// 여기서 2를 나누는 이유는 왕복 시간의 절반만큼 시간을 조정해주기 위함이다.
+	// 즉, 서버에서 클라이언트로 오는 편도 시간을 계산하기 위함
+	float AdjustTime = InServerTime + RoundTrip / 2.0f;
+	
+	ServerTime = AdjustTime;
+}
+

--- a/Source/ProjectR/KartGame/Games/Component/NetworkClockComponent.h
+++ b/Source/ProjectR/KartGame/Games/Component/NetworkClockComponent.h
@@ -1,0 +1,42 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "CommonUtil.h"
+#include "Components/ActorComponent.h"
+#include "NetworkClockComponent.generated.h"
+
+
+UCLASS(ClassGroup=(Custom), meta=(BlueprintSpawnableComponent))
+class PROJECTR_API UNetworkClockComponent : public UActorComponent
+{
+	GENERATED_BODY()
+
+public:
+	// Sets default values for this component's properties
+	UNetworkClockComponent();
+
+protected:
+	// Called when the game starts
+	virtual void BeginPlay() override;
+
+public:
+	// Called every frame
+	virtual void TickComponent(float DeltaTime, ELevelTick TickType,
+	                           FActorComponentTickFunction* ThisTickFunction) override;
+
+	void RequestServerTime(APlayerController* Requester);
+
+	// 서버 시간을 요청하는 함수
+	UFUNCTION(Server, Reliable)
+	void ServerRPC_RequestServerTime(APlayerController* Requester, float RequestTime);
+
+	UFUNCTION(Client, Reliable)
+	void ClientRPC_ReceiveServerTime(float InServerTime, float RequestTime);
+	
+	GETTER(float, ServerTime);
+
+private:
+	float ServerTime = 0.0f;
+};

--- a/Source/ProjectR/KartGame/Games/Modes/Race/RaceGameState.cpp
+++ b/Source/ProjectR/KartGame/Games/Modes/Race/RaceGameState.cpp
@@ -71,6 +71,12 @@ void ARaceGameState::Tick(float DeltaSeconds)
 	Super::Tick(DeltaSeconds);
 
 	SortRank();
+
+	if (GetLocalRole() == ROLE_Authority)
+	{
+		// 서버 시간을 계속해서 업데이트한다.
+		ServerWorldTimeSeconds = GetWorld()->GetTimeSeconds();
+	}
 }
 
 void ARaceGameState::SortRank()
@@ -138,6 +144,31 @@ void ARaceGameState::SortRank()
 		PS->SetRanking(Rank);
 	}
 }
+
+#pragma region NetworkClock
+double ARaceGameState::GetServerWorldTimeSeconds() const
+{
+	// 기존의 시간을 가져오는 함수를 사용하지 않고, 서버 시간을 가져오도록 변경한다.
+	// return Super::GetServerWorldTimeSeconds();
+
+	// 서버 자기 자신이 요청하는 경우 서버 시간을 반환한다.
+	if (GetLocalRole() == ROLE_Authority)
+	{
+		return ServerWorldTimeSeconds;
+	}
+
+	// 클라이언트가 요청하는 경우 클라이언트가 서버와 직접 동기화된 시간을 가져온다.
+	// FirstPlayerController를 가져오는 이유는 해당 플레이어 컨트롤러에서만 관리되기 때문이다.
+	if(ARacePlayerController* PC = Cast<ARacePlayerController>(GetGameInstance()->GetFirstLocalPlayerController(GetWorld())))
+	{
+		return PC->GetServerTime();
+	}
+	else
+	{
+		return GetWorld()->GetTimeSeconds();
+	}
+}
+#pragma endregion
 
 void ARaceGameState::CountDownToFinish(const FDateTime& FinishTime)
 {

--- a/Source/ProjectR/KartGame/Games/Modes/Race/RaceGameState.h
+++ b/Source/ProjectR/KartGame/Games/Modes/Race/RaceGameState.h
@@ -37,7 +37,7 @@ protected:
 	virtual void Tick(float DeltaSeconds) override;
 	
 	virtual void GetLifetimeReplicatedProps(TArray<FLifetimeProperty>& OutLifetimeProps) const override;
-	
+
 private:
 	uint8 MaxLaps = 3;
 	
@@ -61,4 +61,20 @@ private:
 	
 	UPROPERTY(Replicated)
 	FDateTime RaceEndTime;
+
+#pragma region NetworkClock
+
+public:
+	virtual double GetServerWorldTimeSeconds() const override;
+	
+	
+private:
+	// 서버의 시간 (앞으로 모든 클라이언트들이 해당 시간을 동기화 할 거임)
+	// 해당 기능이 필요한 이유는 네트워크 지연으로 인한 시간 불일치를 해결하여
+	// Dead Reckoning과 같은 동기화 처리를 할 때 반드시 필요로 함
+	// 즉, Replicated를 하면 나타나는 네트워크 지연을
+	// 보상하기 위한 정확한 시간을 동기화하기 위함
+	double ServerWorldTimeSeconds = 0.0f;
+	
+#pragma endregion
 };

--- a/Source/ProjectR/KartGame/Games/Modes/Race/RacePlayerController.cpp
+++ b/Source/ProjectR/KartGame/Games/Modes/Race/RacePlayerController.cpp
@@ -7,6 +7,7 @@
 #include "RaceGameState.h"
 #include "KartGame/UIs/HUD/MainUI.h"
 #include "GameFramework/PlayerStart.h"
+#include "KartGame/Games/Component/NetworkClockComponent.h"
 #include "KartGame/UIs/HUD/CountDown/CountDownToEnd.h"
 #include "KartGame/UIs/HUD/CountDown/CountDownToStart.h"
 #include "KartGame/Games/Component/PingManagerComponent.h"
@@ -17,6 +18,12 @@ ARacePlayerController::ARacePlayerController()
 	PingManagerComponent = CreateDefaultSubobject<UPingManagerComponent>("Ping Manager Component");
 	PingManagerComponent->SetNetAddressable();
 	PingManagerComponent->SetIsReplicated(true);
+
+#pragma region NetworkClock
+	NetworkClockComponent = CreateDefaultSubobject<UNetworkClockComponent>("Network Clock Component");
+	NetworkClockComponent->SetNetAddressable();
+	NetworkClockComponent->SetIsReplicated(true);
+#pragma endregion
 }
 
 void ARacePlayerController::BeginPlay()
@@ -128,3 +135,28 @@ void ARacePlayerController::StartGameToGameState()
 {
 	GetWorld()->GetAuthGameMode<ARaceGameMode>()->StartGame();
 }
+
+#pragma region NetworkClock
+
+// PlayerController가 서버로부터 생성되었을 때 호출되는 함수
+// 해당 함수에서 서버 시간을 요청한다.
+void ARacePlayerController::ReceivedPlayer()
+{
+	Super::ReceivedPlayer();
+
+	if (NetworkClockComponent)
+	{
+		NetworkClockComponent->RequestServerTime(this);
+	}
+}
+
+float ARacePlayerController::GetServerTime() const
+{
+	if (NetworkClockComponent)
+	{
+		return NetworkClockComponent->GetServerTime();
+	}
+	return GetWorld()->GetTimeSeconds();
+}
+
+#pragma endregion

--- a/Source/ProjectR/KartGame/Games/Modes/Race/RacePlayerController.h
+++ b/Source/ProjectR/KartGame/Games/Modes/Race/RacePlayerController.h
@@ -60,4 +60,19 @@ private:
 
 	UFUNCTION()
 	void StartGameToGameState();
+
+#pragma region NetworkClock
+
+public:
+	float GetServerTime() const;
+	
+protected:
+	// 네트워크 시계를 만들기 위해서 필요한 함수
+	// 아래 함수에서 서버로부터 시간을 받아오도록 요청한다.
+	virtual void ReceivedPlayer() override;
+
+private:
+	UPROPERTY()
+	class UNetworkClockComponent* NetworkClockComponent = nullptr;
+#pragma endregion
 };

--- a/Source/ProjectR/KartGame/Kart/Components/KartInfo.h
+++ b/Source/ProjectR/KartGame/Kart/Components/KartInfo.h
@@ -16,4 +16,6 @@ struct PROJECTR_API FKartInfo
 	FVector Velocity = FVector::ZeroVector;
 	UPROPERTY()
 	FVector TorqueInDegrees = FVector::ZeroVector;
+	UPROPERTY()
+	float TimeStamp = 0.0f;
 };

--- a/Source/ProjectR/KartGame/Kart/Components/KartNetworkSyncComponent.h
+++ b/Source/ProjectR/KartGame/Kart/Components/KartNetworkSyncComponent.h
@@ -49,4 +49,8 @@ private:
 
 	UFUNCTION(Server, Reliable)
 	void Server_SendKartInfo(FKartInfo NewKartInfo);
+
+	// Dead Reckoning : 클라이언트 예측 보간
+	UPROPERTY()
+	class UNetworkInterpolationStrategy* DeadReckoningStrategy = nullptr;
 };

--- a/Source/ProjectR/KartGame/Kart/Kart.cpp
+++ b/Source/ProjectR/KartGame/Kart/Kart.cpp
@@ -334,8 +334,8 @@ void AKart::Tick(float DeltaTime)
 	UpdateSpeedUI();
 
 	// // 네트워크 시간 로그 찍어보기 : 예시 코드 ( 시간을 가져오는 방법 )
-	// FString DebugStr = FString::Printf(TEXT("Network Time : %f"), GetWorld()->GetGameState()->GetServerWorldTimeSeconds());
-	// DrawDebugString(GetWorld(), GetActorLocation(), DebugStr, nullptr, FColor::Cyan, 0.f);
+	FString DebugStr = FString::Printf(TEXT("Network Time : %f"), GetWorld()->GetGameState()->GetServerWorldTimeSeconds());
+	DrawDebugString(GetWorld(), GetActorLocation(), DebugStr, nullptr, FColor::Cyan, 0.f);
 }
 
 // Called to bind functionality to input

--- a/Source/ProjectR/KartGame/Kart/Kart.cpp
+++ b/Source/ProjectR/KartGame/Kart/Kart.cpp
@@ -33,6 +33,7 @@
 #include "Net/UnrealNetwork.h"
 #include "KartPowerBoosterVFXComponent.h"
 #include "SpeedLineUI.h"
+#include "GameFramework/GameStateBase.h"
 
 // Sets default values
 AKart::AKart()
@@ -331,6 +332,10 @@ void AKart::Tick(float DeltaTime)
 		RightSkidMark->ProcessSkidMark(false);
 	}
 	UpdateSpeedUI();
+
+	// // 네트워크 시간 로그 찍어보기 : 예시 코드 ( 시간을 가져오는 방법 )
+	// FString DebugStr = FString::Printf(TEXT("Network Time : %f"), GetWorld()->GetGameState()->GetServerWorldTimeSeconds());
+	// DrawDebugString(GetWorld(), GetActorLocation(), DebugStr, nullptr, FColor::Cyan, 0.f);
 }
 
 // Called to bind functionality to input

--- a/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.cpp
+++ b/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.cpp
@@ -2,3 +2,27 @@
 
 
 #include "DeadReckoningStrategy.h"
+#include "Kart.h"
+
+void UDeadReckoningStrategy::Initialize(class AKart* InKart)
+{
+	Super::Initialize(InKart);
+
+	Kart = InKart;
+}
+
+void UDeadReckoningStrategy::Update(float DeltaTime)
+{
+	Super::Update(DeltaTime);
+
+	// 현재 시간 기준 DeltaTime
+	float CurrentTime = Kart->GetWorld()->GetTimeSeconds();
+}
+
+void UDeadReckoningStrategy::UpdateRemoteState(const FKartInfo& NewKartInfo)
+{
+	Super::UpdateRemoteState(NewKartInfo);
+
+	LastUpdatedKartInfo = NewKartInfo;
+	Kart->GetWorld()->GetFirstPlayerController()->
+}

--- a/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.cpp
+++ b/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.cpp
@@ -1,0 +1,4 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "DeadReckoningStrategy.h"

--- a/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.cpp
+++ b/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.cpp
@@ -24,5 +24,6 @@ void UDeadReckoningStrategy::UpdateRemoteState(const FKartInfo& NewKartInfo)
 	Super::UpdateRemoteState(NewKartInfo);
 
 	LastUpdatedKartInfo = NewKartInfo;
-	Kart->GetWorld()->GetFirstPlayerController()->
+	// TODO : Dead Reckoning을 위한 네트워크 시간을 만들자!
+	// Kart->GetWorld()->GetFirstPlayerController()->
 }

--- a/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.h
+++ b/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.h
@@ -1,0 +1,16 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "NetworkInterpolationStrategy.h"
+#include "DeadReckoningStrategy.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class PROJECTR_API UDeadReckoningStrategy : public UNetworkInterpolationStrategy
+{
+	GENERATED_BODY()
+};

--- a/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.h
+++ b/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.h
@@ -21,8 +21,13 @@ public:
 
 private:
 	UPROPERTY()
-	AKart* Kart = nullptr;
+	class AKart* Kart = nullptr;
+	UPROPERTY()
+	class UBoxComponent* KartBody = nullptr;
 
 	UPROPERTY()
 	FKartInfo LastUpdatedKartInfo;
+
+	FVector PredictedPosition;
+	FRotator PredictedRotation;
 };

--- a/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.h
+++ b/Source/ProjectR/KartGame/Kart/Objects/DeadReckoningStrategy.h
@@ -13,4 +13,16 @@ UCLASS()
 class PROJECTR_API UDeadReckoningStrategy : public UNetworkInterpolationStrategy
 {
 	GENERATED_BODY()
+
+public:
+	virtual void Initialize(class AKart* InKart) override;
+	virtual void Update(float DeltaTime) override;
+	virtual void UpdateRemoteState(const FKartInfo& NewKartInfo) override;
+
+private:
+	UPROPERTY()
+	AKart* Kart = nullptr;
+
+	UPROPERTY()
+	FKartInfo LastUpdatedKartInfo;
 };

--- a/Source/ProjectR/KartGame/Kart/Objects/NetworkInterpolationStrategy.cpp
+++ b/Source/ProjectR/KartGame/Kart/Objects/NetworkInterpolationStrategy.cpp
@@ -1,0 +1,4 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+
+#include "NetworkInterpolationStrategy.h"

--- a/Source/ProjectR/KartGame/Kart/Objects/NetworkInterpolationStrategy.h
+++ b/Source/ProjectR/KartGame/Kart/Objects/NetworkInterpolationStrategy.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "KartInfo.h"
 #include "UObject/Object.h"
 #include "NetworkInterpolationStrategy.generated.h"
 
@@ -13,4 +14,9 @@ UCLASS()
 class PROJECTR_API UNetworkInterpolationStrategy : public UObject
 {
 	GENERATED_BODY()
+
+public:
+	virtual void Initialize(class AKart* InKart) {};
+	virtual void Update(float DeltaTime) {};
+	virtual void UpdateRemoteState(const FKartInfo& NewKartInfo) {};
 };

--- a/Source/ProjectR/KartGame/Kart/Objects/NetworkInterpolationStrategy.h
+++ b/Source/ProjectR/KartGame/Kart/Objects/NetworkInterpolationStrategy.h
@@ -1,0 +1,16 @@
+// Fill out your copyright notice in the Description page of Project Settings.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "UObject/Object.h"
+#include "NetworkInterpolationStrategy.generated.h"
+
+/**
+ * 
+ */
+UCLASS()
+class PROJECTR_API UNetworkInterpolationStrategy : public UObject
+{
+	GENERATED_BODY()
+};

--- a/Source/ProjectR/ProjectR.Build.cs
+++ b/Source/ProjectR/ProjectR.Build.cs
@@ -26,6 +26,7 @@ public class ProjectR : ModuleRules
 			"ProjectR/",
 			"ProjectR/KartGame/Kart/",
 			"ProjectR/KartGame/Kart/Components/",
+			"ProjectR/KartGame/Kart/Objects/",
 			"ProjectR/KartGame/Kart/Utils/",
 			"ProjectR/KartGame/Utils/",
 			"ProjectR/KartGame/Kart/Animations/",


### PR DESCRIPTION
# Key Added
- 네트워크에서 완전히 동일한 시계를 만듬
  - 네트워크 지연을 고려한 시계 (즉, 완전히 일치한 시간을 서로 가지고 있음)
  - 필요했던 이유, 클라이언트 및 서버가 다른 유저들의 위치를 보간하기 위해서는 상대방이 해당 동작을 취했던 정확한 시간이 필요했고 모두가 동일한 시간을 필요로 하기 때문
  
- Dead Reckoning (클라이언트 예측 보간 기법) 적용 완료
  - 이로 인해서 모든 유저가 정확히 동일한 화면을 볼 수 있게 됨. 그래서 자기 자신이 더 빠르다고 생각하는 문제가 사라지게 됨.